### PR TITLE
fix: add configurable Claude Code executable path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,31 @@ Make sure you're authenticated with Claude Code:
 claude setup-token
 ```
 
+### "Claude Code executable not found" error
+
+If you encounter an error about the Claude Code executable not being found, you can specify the path explicitly using environment variables:
+
+```json
+{
+  "agent_servers": {
+    "claude-code": {
+      "command": "npx",
+      "args": ["acp-claude-code"],
+      "env": {
+        "CLAUDE_CODE_EXECUTABLE_PATH": "/Users/YOUR_USERNAME/.local/bin/claude"
+      }
+    }
+  }
+}
+```
+
+To find your Claude executable path:
+```bash
+which claude
+```
+
+You can also use the alternative environment variable `ACP_CLAUDE_EXECUTABLE_PATH`.
+
 ### Tool calls not working
 
 Tool calls are fully supported. Ensure your Zed client is configured to handle tool call updates properly.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -13,7 +13,6 @@ import {
   PromptResponse,
   CancelNotification,
   LoadSessionRequest,
-  LoadSessionResponse,
 } from "@zed-industries/agent-client-protocol";
 import type { ClaudeMessage, ClaudeStreamEvent } from "./types.js";
 
@@ -37,9 +36,15 @@ export class ClaudeACPAgent implements Agent {
       | "acceptEdits"
       | "bypassPermissions"
       | "plan") || "default";
+  private claudeExecutablePath: string | undefined =
+    process.env.CLAUDE_CODE_EXECUTABLE_PATH ||
+    process.env.ACP_CLAUDE_EXECUTABLE_PATH;
 
   constructor(private client: Client) {
     this.log("Initialized with client");
+    if (this.claudeExecutablePath) {
+      this.log(`Using custom Claude executable path: ${this.claudeExecutablePath}`);
+    }
   }
 
   private log(message: string, ...args: unknown[]) {
@@ -190,6 +195,8 @@ export class ClaudeACPAgent implements Agent {
           permissionMode: permissionMode,
           // Resume if we have a Claude session_id
           resume: session.claudeSessionId || undefined,
+          // Use custom executable path if configured
+          pathToClaudeCodeExecutable: this.claudeExecutablePath,
         },
       });
 


### PR DESCRIPTION
## Summary

This PR adds support for configuring the Claude Code executable path via environment variables, fixing an issue where the SDK fails to find the Claude CLI in non-standard installation locations.

## Problem

When using the ACP bridge with Zed editor, users may encounter an error:
```
Error: Claude Code executable not found at /Users/.../acp-claude-code/node_modules/@anthropic-ai/entrypoints/cli.js
```

This occurs because:
1. The Claude Code SDK looks for the CLI in the wrong location (looking for `@anthropic-ai/entrypoints/cli.js` when it's actually at `@anthropic-ai/claude-code/cli.js`)
2. The globally installed Claude CLI may be in a custom location (e.g., `~/.local/bin/claude`) that differs from the system PATH

## Solution

Added support for configuring the Claude Code executable path through environment variables:
- `CLAUDE_CODE_EXECUTABLE_PATH` (primary)
- `ACP_CLAUDE_EXECUTABLE_PATH` (alternative)

The configured path is passed to the Claude Code SDK's `query` function via the `pathToClaudeCodeExecutable` option, which is already supported by the SDK (as documented in the SDK type definitions).

## Changes

1. **src/agent.ts**:
   - Added `claudeExecutablePath` property that reads from environment variables
   - Pass the path to the SDK's query function options
   - Log when using a custom executable path for debugging

2. **README.md**:
   - Added troubleshooting section for the "executable not found" error
   - Documented how to configure the path in Zed settings
   - Included instructions to find the Claude executable path

## Manual Verification

Tested by @trieloff in Zed editor with the following configuration:
```json
"agent_servers": {
  "claude-code": {
    "command": "node",
    "args": ["/Users/trieloff/Developer/acp-claude-code/dist/cli.js"],
    "env": {
      "ACP_PERMISSION_MODE": "bypassPermissions",
      "CLAUDE_CODE_EXECUTABLE_PATH": "/Users/trieloff/.local/bin/claude"
    }
  }
}
```

✅ Confirmed the error is resolved and Claude Code works correctly with the custom path.

## Compatibility

This change is backward compatible - if no environment variable is set, the behavior remains unchanged and the SDK will use its default path resolution.

🤖 Generated with [Claude Code](https://claude.ai/code)